### PR TITLE
Assorted fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Eclipse #
+/.classpath
+/.project
+/.settings/
+
+# Maven #
+/target/

--- a/src/main/java/org/kohsuke/maven/pgp/PgpMojo.java
+++ b/src/main/java/org/kohsuke/maven/pgp/PgpMojo.java
@@ -184,11 +184,8 @@ public class PgpMojo extends AbstractMojo
      * Sign and attach the signature to the build.
      */
     protected void sign(Signer signer, Artifact a) throws MojoExecutionException {
-        String name = a.getGroupId() + "-" + a.getArtifactId();
-        if (a.getClassifier()!=null)
-            name += '-'+a.getClassifier();
-        name += '.'+a.getArtifactHandler().getExtension();
-        name += ".asc";
+        File file = a.getFile();
+        String name = file.getName() + ".asc";
 
         File signature = new File(outputDirectory,name);
 

--- a/src/main/java/org/kohsuke/maven/pgp/PgpMojo.java
+++ b/src/main/java/org/kohsuke/maven/pgp/PgpMojo.java
@@ -181,7 +181,7 @@ public class PgpMojo extends AbstractMojo
     }
 
     /**
-     * Sign and attach the signaature to the build.
+     * Sign and attach the signature to the build.
      */
     protected void sign(Signer signer, Artifact a) throws MojoExecutionException {
         String name = a.getGroupId() + "-" + a.getArtifactId();

--- a/src/main/java/org/kohsuke/maven/pgp/Signer.java
+++ b/src/main/java/org/kohsuke/maven/pgp/Signer.java
@@ -38,6 +38,10 @@ class Signer {
     Signer(PGPSecretKey secretKey, char[] passphrase) {
         try {
             this.privateKey = secretKey.extractPrivateKey(passphrase,PROVIDER);
+            if (this.privateKey == null)
+                throw new IllegalArgumentException("Unsupported signing key"
+                    + (secretKey.getKeyEncryptionAlgorithm() == PGPPublicKey.RSA_SIGN ?
+                       ": RSA (sign-only) is unsupported by BouncyCastle" : ""));
             this.publicKey = secretKey.getPublicKey();
         } catch (PGPException e) {
             throw new IllegalArgumentException("Passphrase is incorrect",e);


### PR DESCRIPTION
The most important fix is the one changing the signature files' names to appropriate ones. It actually would merit an increment of the major version according to [SemVer](http://semver.org/).

The other important change is to give a more helpful message to the user than a `NullPointerException` when BouncyCastle fails to handle an RSA (sign-only) key properly (it _can_ handle DSA (sign-only) keys just fine...).
