### PR TITLE
Fix #4: Add support for EC keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -28,8 +30,8 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpg-jdk15</artifactId>
-      <version>1.46</version>
+      <artifactId>bcpg-jdk15on</artifactId>
+      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/main/java/org/kohsuke/maven/pgp/loaders/GpgAgentPassPhraseLoader.java
+++ b/src/main/java/org/kohsuke/maven/pgp/loaders/GpgAgentPassPhraseLoader.java
@@ -7,6 +7,10 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPSecretKey;
+import org.bouncycastle.openpgp.operator.PBESecretKeyDecryptor;
+import org.bouncycastle.openpgp.operator.PGPDigestCalculatorProvider;
+import org.bouncycastle.openpgp.operator.bc.BcPBESecretKeyDecryptorBuilder;
+import org.bouncycastle.openpgp.operator.bc.BcPGPDigestCalculatorProvider;
 import org.bouncycastle.util.encoders.Hex;
 import org.codehaus.plexus.component.annotations.Component;
 import org.kohsuke.maven.pgp.PassphraseLoader;
@@ -120,7 +124,10 @@ public class GpgAgentPassPhraseLoader extends PassphraseLoader {
 
                 String phrase = new String(Hex.decode(expectOK(in).trim()));
                 try {
-                    secretKey.extractPrivateKey(phrase.toCharArray(),new BouncyCastleProvider());
+                    PGPDigestCalculatorProvider pgpDigestCalculatorProvider = new BcPGPDigestCalculatorProvider();
+                    PBESecretKeyDecryptor decryptor = new BcPBESecretKeyDecryptorBuilder(pgpDigestCalculatorProvider)
+                            .build(phrase.toCharArray());
+                    secretKey.extractPrivateKey(decryptor);
                     return phrase;
                 } catch (PGPException e) {
                     // invalid pass phrase

--- a/src/main/java/org/kohsuke/maven/pgp/loaders/KeyFileLoader.java
+++ b/src/main/java/org/kohsuke/maven/pgp/loaders/KeyFileLoader.java
@@ -4,6 +4,7 @@ import org.bouncycastle.openpgp.PGPObjectFactory;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 import org.codehaus.plexus.component.annotations.Component;
 import org.kohsuke.maven.pgp.PgpMojo;
 import org.kohsuke.maven.pgp.SecretKeyLoader;
@@ -24,7 +25,7 @@ public class KeyFileLoader extends SecretKeyLoader {
     public PGPSecretKey load(PgpMojo mojo, String keyFile) throws IOException {
         FileInputStream in = new FileInputStream(new File(keyFile));
         try {
-            PGPObjectFactory pgpF = new PGPObjectFactory(PGPUtil.getDecoderStream(in));
+            PGPObjectFactory pgpF = new PGPObjectFactory(PGPUtil.getDecoderStream(in), new BcKeyFingerprintCalculator());
             Object o = pgpF.nextObject();
             if (!(o instanceof PGPSecretKeyRing)) {
                 throw new IOException(keyFile+" doesn't contain PGP private key");

--- a/src/main/java/org/kohsuke/maven/pgp/loaders/KeyRingLoader.java
+++ b/src/main/java/org/kohsuke/maven/pgp/loaders/KeyRingLoader.java
@@ -4,6 +4,7 @@ import org.bouncycastle.openpgp.PGPObjectFactory;
 import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.bouncycastle.openpgp.PGPUtil;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
 import org.codehaus.plexus.component.annotations.Component;
 import org.kohsuke.maven.pgp.PgpMojo;
 import org.kohsuke.maven.pgp.SecretKeyLoader;
@@ -39,7 +40,7 @@ public class KeyRingLoader extends SecretKeyLoader {
 
         InputStream in = PGPUtil.getDecoderStream(new FileInputStream(keyFile));
         try {
-            PGPObjectFactory pgpFact = new PGPObjectFactory(in);
+            PGPObjectFactory pgpFact = new PGPObjectFactory(in, new BcKeyFingerprintCalculator());
 
             Object              obj;
             while ((obj = pgpFact.nextObject()) != null)


### PR DESCRIPTION
This pull request contains following improvements:
- update of `bcpg-jdk15on` library to version `1.69` which contains support for PGP EC keys and various bug fixes compared to version `1.46`
- migration to builders introduced in more recent version of the `bcpg-jdk15on` library
- compilation source and target set to Java 8 to allow building on Java 11 or higher

I tested creating PGP signatures and their verification with a key generated on EC curve 25519. This doesn't work in the `1.1` version of the plug-in where you get the error `unknown PGP public key algorithm encountered`.